### PR TITLE
Fix errors in Dockerfile from previous commits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,14 @@ WORKDIR /build
 
 COPY pom.xml .
 COPY settings.xml .
-COPY brouter-codec .
-COPY brouter-core .
-COPY brouter-expressions .
-COPY brouter-map-creator .
-COPY brouter-mapaccess .
-COPY brouter-routing-app .
-COPY brouter-server .
-COPY brouter-util .
+COPY brouter-codec brouter-codec
+COPY brouter-core brouter-core
+COPY brouter-expressions brouter-expressions
+COPY brouter-map-creator brouter-map-creator
+COPY brouter-mapaccess brouter-mapaccess
+COPY brouter-routing-app brouter-routing-app
+COPY brouter-server brouter-server
+COPY brouter-util brouter-util
 
 RUN mvn clean install -pl '!brouter-routing-app' '-Dmaven.javadoc.skip=true' -DskipTests
 
@@ -34,4 +34,4 @@ COPY get_segments.sh get_segments.sh
 
 EXPOSE 17777
 
-CMD server.sh
+CMD ./server.sh


### PR DESCRIPTION
Previous commits introduced errors in Dockerfile:
- removal of `./` in CMD before path to script introduced in c5c8aa8
- change `<dest>` in COPY to `.` introduced in 7c96e2a

This commit reverts those changes